### PR TITLE
Added an updated function signature for Swift 6 typed throws

### DIFF
--- a/Sources/OptionalTools/unwrappedOrThrow.swift
+++ b/Sources/OptionalTools/unwrappedOrThrow.swift
@@ -8,6 +8,36 @@
 
 
 
+#if compiler(>=6) || swift(>=6)
+public extension Optional {
+    
+    /// If this contains a value, it is returned. Otherwise, the given error is thrown.
+    ///
+    /// - Parameter error: _optional_ - The error to throw if there is no value to return.
+    ///                    Defaults to `UnexpectedlyFoundNilError`
+    ///
+    /// - Throws: The given `error` if this is `nil`
+    @inline(__always)
+    func unwrappedOrThrow() throws(UnexpectedlyFoundNilError) -> Wrapped {
+        try unwrappedOrThrow(error: UnexpectedlyFoundNilError())
+    }
+    
+    
+    /// If this contains a value, it is returned. Otherwise, the given error is thrown.
+    ///
+    /// - Parameter error: _optional_ - The error to throw if there is no value to return.
+    ///                    Defaults to `UnexpectedlyFoundNilError`
+    ///
+    /// - Throws: The given `error` if this is `nil`
+    @inlinable
+    func unwrappedOrThrow<ErrorToThrow>(error: @autoclosure () -> ErrorToThrow) throws(ErrorToThrow) -> Wrapped {
+        switch self {
+        case .some(let wrapped): return wrapped
+        case .none: throw error()
+        }
+    }
+}
+#else
 public extension Optional {
     
     /// If this contains a value, it is returned. Otherwise, an error is thrown.
@@ -21,6 +51,7 @@ public extension Optional {
         }
     }
 }
+#endif
 
 
 


### PR DESCRIPTION
This also necessitates 2 functions, so the implied-type one is an inline wrapper function around the generic one
